### PR TITLE
add error code parameter

### DIFF
--- a/src/Contracts/PhpRestfulApiResponse.php
+++ b/src/Contracts/PhpRestfulApiResponse.php
@@ -50,90 +50,100 @@ interface PhpRestfulApiResponse extends ResponseInterface
      * Generates a response with custom code HTTP header and a given message.
      *
      * @param $message
-     * @param $code
+     * @param int $statusCode
+     * @param int|string $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function withError($message, $code, array $headers = []);
+    public function withError($message, int $statusCode, $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 403 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorForbidden(string $message = '', array $headers = []);
+    public function errorForbidden(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 500 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorInternalError(string $message = '', array $headers = []);
+    public function errorInternalError(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 404 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorNotFound(string $message = '', array $headers = []);
+    public function errorNotFound(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 401 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorUnauthorized(string $message = '', array $headers = []);
+    public function errorUnauthorized(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 400 HTTP header and a given message.
      *
      * @param array $message
+     * @param int|array $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorWrongArgs(array $message, array $headers = []);
+    public function errorWrongArgs(array $message, $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 410 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorGone(string $message = '', array $headers = []);
+    public function errorGone(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a response with a 405 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorMethodNotAllowed(string $message = '', array $headers = []);
+    public function errorMethodNotAllowed(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a Response with a 431 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorUnwillingToProcess(string $message = '', array $headers = []);
+    public function errorUnwillingToProcess(string $message = '', $errorCode, array $headers = []);
 
     /**
      * Generates a Response with a 422 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorUnprocessable(string $message = '', array $headers = []);
+    public function errorUnprocessable(string $message = '', $errorCode, array $headers = []);
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -114,14 +114,21 @@ class Response implements PhpRestfulApiResponse
     private $statusCode;
 
     /**
+     * @var int|string
+     */
+    private $errorCode;
+
+    /**
      * Response constructor.
      * @param string $body
      * @param int $status
+     * @param int $errorCode
      * @param array $headers
      */
-    public function __construct($body = 'php://memory', $status = 200, array $headers = [])
+    public function __construct($body = 'php://memory', int $status = 200, $errorCode = null, array $headers = [])
     {
         $this->setStatusCode($status);
+        $this->setErrorCode($errorCode);
         $this->stream = $this->getStream($body, 'wb+');
         $this->setHeaders($headers);
     }
@@ -232,19 +239,22 @@ class Response implements PhpRestfulApiResponse
      * Response for errors
      *
      * @param string|array $message
-     * @param int $code
+     * @param int $statusCode
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function withError($message, $code, array $headers = [])
+    public function withError($message, int $statusCode, $errorCode = null, array $headers = [])
     {
         $new = clone $this;
-        $new->setStatusCode($code);
+        $new->setStatusCode($statusCode);
+        $new->setErrorCode($errorCode);
         $new->getBody()->write(
             json_encode(
                 [
                     'error' => array_filter([
                         'http_code' => $new->statusCode,
+                        'code' => $errorCode,
                         'phrase' => $new->getReasonPhrase(),
                         'message' => $message
                     ])
@@ -260,128 +270,154 @@ class Response implements PhpRestfulApiResponse
      * Generates a response with a 403 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorForbidden(string $message = '', array $headers = [])
+    public function errorForbidden(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 403, $headers);
+        return $this->withError($message, 403, $errorCode, $headers);
     }
 
     /**
      * Generates a response with a 500 HTTP header and a given message.
      *
      * @param string $message
-     * @param array  $headers
+     * @param int|string $errorCode
+     * @param array $headers
      * @return mixed
      */
-    public function errorInternalError(string $message = '', array $headers = [])
+    public function errorInternalError(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 500, $headers);
+        return $this->withError($message, 500, $errorCode, $headers);
     }
 
     /**
      * Generates a response with a 404 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array  $headers
      * @return mixed
      */
-    public function errorNotFound(string $message = '', array $headers = [])
+    public function errorNotFound(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 404, $headers);
+        return $this->withError($message, 404, $errorCode, $headers);
     }
 
     /**
      * Generates a response with a 401 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function errorUnauthorized(string $message = '', array $headers = [])
+    public function errorUnauthorized(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 401, $headers);
+        return $this->withError($message, 401, $errorCode, $headers);
     }
 
     /**
      * Generates a response with a 400 HTTP header and a given message.
      *
      * @param array $message
+     * @param int|array $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function errorWrongArgs(array $message, array $headers = [])
+    public function errorWrongArgs(array $message, $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 400, $headers);
+        return $this->withError($message, 400, $errorCode, $headers);
     }
 
     /**
      * Generates a response with a 410 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function errorGone(string $message = '', array $headers = [])
+    public function errorGone(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 410, $headers);
+        return $this->withError($message, 410, $errorCode, $headers);
     }
 
     /**
      * Generates a response with a 405 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function errorMethodNotAllowed(string $message = '', array $headers = [])
+    public function errorMethodNotAllowed(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 405, $headers);
+        return $this->withError($message, 405, $errorCode, $headers);
     }
 
     /**
      * Generates a Response with a 431 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function errorUnwillingToProcess(string $message = '', array $headers = [])
+    public function errorUnwillingToProcess(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 431, $headers);
+        return $this->withError($message, 431, $errorCode, $headers);
     }
 
     /**
      * Generates a Response with a 422 HTTP header and a given message.
      *
      * @param string $message
+     * @param int|string $errorCode
      * @param array $headers
      * @return mixed
      */
-    public function errorUnprocessable(string $message = '', array $headers = [])
+    public function errorUnprocessable(string $message = '', $errorCode = null, array $headers = [])
     {
-        return $this->withError($message, 422, $headers);
+        return $this->withError($message, 422, $errorCode, $headers);
+    }
+
+    /**
+     * @return int|string
+     */
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * @param $errorCode
+     * @return $this
+     */
+    public function setErrorCode($errorCode)
+    {
+        $this->errorCode = $errorCode;
     }
 
     /**
      * Set a valid status code.
      *
-     * @param int $code
+     * @param int $statusCode
      * @throws InvalidArgumentException on an invalid status code.
      */
-    private function setStatusCode(int $code)
+    private function setStatusCode(int $statusCode)
     {
-        if ($code < static::MIN_STATUS_CODE_VALUE
-            || $code > static::MAX_STATUS_CODE_VALUE
+        if ($statusCode < static::MIN_STATUS_CODE_VALUE
+            || $statusCode > static::MAX_STATUS_CODE_VALUE
         ) {
             throw new InvalidArgumentException(sprintf(
                 'Invalid status code "%s"; must be an integer between %d and %d, inclusive',
-                (is_scalar($code) ? $code : gettype($code)),
+                (is_scalar($statusCode) ? $statusCode : gettype($statusCode)),
                 static::MIN_STATUS_CODE_VALUE,
                 static::MAX_STATUS_CODE_VALUE
             ));
         }
-        $this->statusCode = $code;
+        $this->statusCode = $statusCode;
     }
 }

--- a/tests/unit/ResponseTest.php
+++ b/tests/unit/ResponseTest.php
@@ -73,6 +73,19 @@ class ResponseTest extends Base
         );
     }
 
+    public function test_withError_with_param_errorCode()
+    {
+        $code = 400;
+        $message = 'error occured';
+        $errorCode = 'ERROR-CODE';
+        $this->withError(
+            $this->response->withError($message, $code, $errorCode),
+            $code,
+            $message,
+            $errorCode
+        );
+    }
+
     public function test_errorNotFound()
     {
         $code = 404;
@@ -284,6 +297,11 @@ class ResponseTest extends Base
         $this->run_setStatusCode($this->getMethodSetStatusCode(), 200);
     }
 
+    public function test_setErrorCode()
+    {
+        $this->run_setErrorCode($this->getMethodSetErrorCode(), "ERROR-CODE");
+    }
+
     private function run_setStatusCode(\ReflectionMethod $method, $code)
     {
         try {
@@ -297,6 +315,20 @@ class ResponseTest extends Base
         }
     }
 
+    private function run_setErrorCode(\ReflectionMethod $method, $code)
+    {
+        $method->invokeArgs($this->response, [$code]);
+        $this->assertEquals($code, $this->response->getErrorCode());
+    }
+
+    private function getMethodSetErrorCode()
+    {
+        $responseReflect = new ReflectionClass(Response::class);
+        $method = $responseReflect->getMethod('setErrorCode');
+        $method->setAccessible(true);
+        return $method;
+    }
+
     private function getMethodSetStatusCode()
     {
         $responseReflect = new ReflectionClass(Response::class);
@@ -306,12 +338,15 @@ class ResponseTest extends Base
     }
 
 
-    private function withError(Response $response, $code, $message = null)
+    private function withError(Response $response, $code, $message = null, $errorCode = null)
     {
         $this->assertEquals($code, $response->getStatusCode());
+        $this->assertEquals($errorCode, $response->getErrorCode());
+
         $this->assertEquals(json_encode([
             'error' => array_filter([
                 'http_code' => $response->getStatusCode(),
+                'code' => $response->getErrorCode(),
                 'phrase' => $response->getReasonPhrase(),
                 'message' => $message
             ])


### PR DESCRIPTION
```
/**
     * Response for errors
     *
     * @param string|array $message
     * @param int $statusCode
     * @param int|string $errorCode
     * @param array  $headers
     * @return mixed
     */
    public function withError($message, int $statusCode, $errorCode = null, array $headers = [])
    {
        $new = clone $this;
        $new->setStatusCode($statusCode);
        $new->setErrorCode($errorCode);
        $new->getBody()->write(
            json_encode(
                [
                    'error' => array_filter([
                        'http_code' => $new->statusCode,
                        'code' => $errorCode,
                        'phrase' => $new->getReasonPhrase(),
                        'message' => $message
                    ])
                ]
            )
        );
        $new = $new->withHeader('Content-Type', 'application/json');
        $new->headers = array_merge($new->headers, $headers);
        return $new;
    }
```